### PR TITLE
add default constructor to inputdevice, and missing symbols

### DIFF
--- a/include/miroil/miroil/input_device.h
+++ b/include/miroil/miroil/input_device.h
@@ -29,6 +29,7 @@ public:
     InputDevice(std::shared_ptr<mir::input::Device> const& device);
     InputDevice(InputDevice const& src);
     InputDevice(InputDevice&& src);
+    InputDevice();
     ~InputDevice();
 
     auto operator=(InputDevice const& src) -> InputDevice&;

--- a/src/miroil/input_device.cpp
+++ b/src/miroil/input_device.cpp
@@ -27,6 +27,8 @@ miroil::InputDevice::InputDevice(std::shared_ptr<mir::input::Device> const& devi
 
 miroil::InputDevice::InputDevice(InputDevice const& ) = default;
 
+miroil::InputDevice::InputDevice() = default;
+
 miroil::InputDevice::~InputDevice() = default;
 
 bool miroil::InputDevice::operator==(InputDevice const& other)

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -31,6 +31,7 @@ global:
     miroil::InputDevice::is_alpha_numeric*;
     miroil::InputDevice::is_keyboard*;
     miroil::InputDevice::operator*;
+    miroil::InputDeviceObserver::?InputDeviceObserver*;
     miroil::InputDeviceObserver::InputDeviceObserver*;
     miroil::InputDeviceObserver::operator*;
     miroil::PersistDisplayConfig::?PersistDisplayConfig*;
@@ -49,6 +50,7 @@ global:
     miroil::dispatch_input_event*;
     non-virtual?thunk?to?miroil::DisplayConfigurationPolicy::?DisplayConfigurationPolicy*;
     non-virtual?thunk?to?miroil::DisplayConfigurationStorage::?DisplayConfigurationStorage*;
+    non-virtual?thunk?to?miroil::InputDeviceObserver::?InputDeviceObserver*;
     non-virtual?thunk?to?miroil::PromptSessionListener::?PromptSessionListener*;
     typeinfo?for?miroil::DisplayConfigurationOptions;
     typeinfo?for?miroil::DisplayConfigurationOptions::DisplayMode;


### PR DESCRIPTION
Adding default constructor to InputDevice
And fixing missing symbols... ~InputDeviceObserver