### PR TITLE
Miroil set composer

### DIFF
--- a/include/miroil/miroil/compositor.h
+++ b/include/miroil/miroil/compositor.h
@@ -20,15 +20,15 @@
 namespace miroil
 {
 
-class Compositor 
+class Compositor
 {
     public:
     virtual ~Compositor();
 
     Compositor& operator=(Compositor const&) = delete;
-    
+
     virtual void start() = 0;
-    virtual void stop()  = 0;        
+    virtual void stop()  = 0;
 
 protected:
     Compositor() = default;
@@ -38,9 +38,3 @@ protected:
 }
 
 #endif // MIROIL_COMPOSITOR_H
-
-
-
-
-
-

--- a/include/miroil/miroil/compositor.h
+++ b/include/miroil/miroil/compositor.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIROIL_COMPOSITOR_H
+#define MIROIL_COMPOSITOR_H
+
+namespace miroil
+{
+
+class Compositor 
+{
+    public:
+    virtual ~Compositor();
+
+    Compositor& operator=(Compositor const&) = delete;
+    
+    virtual void start() = 0;
+    virtual void stop()  = 0;        
+
+protected:
+    Compositor() = default;
+    Compositor(Compositor const&) = delete;
+};
+
+}
+
+#endif // MIROIL_COMPOSITOR_H
+
+
+
+
+
+

--- a/include/miroil/miroil/set_compositor.h
+++ b/include/miroil/miroil/set_compositor.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIROIL_SET_COMPOSITOR_H
+#define MIROIL_SET_COMPOSITOR_H
+#include <memory>
+#include <functional>
+
+namespace mir { class Server; }
+namespace mir { namespace graphics { class Display; } }
+namespace mir { namespace compositor { class DisplayListener; } } 
+
+namespace miroil
+{
+    class Compositor;
+       
+// Configure the server for using the Qt compositor
+class SetCompositor
+{
+    using initFunction = std::function<void(const std::shared_ptr<mir::graphics::Display>& display,
+                       const std::shared_ptr<Compositor> & compositor,
+                       const std::shared_ptr<mir::compositor::DisplayListener>& displayListener)>;
+                       
+    using constructorFunction = std::function<std::shared_ptr<Compositor>()>;    
+    
+public:
+    SetCompositor(constructorFunction constructor, initFunction init);
+    
+    void operator()(mir::Server& server);
+
+private:
+    struct CompositorImpl;
+    
+    std::weak_ptr<CompositorImpl> compositor_impl;
+    constructorFunction           constructor_function;    
+    initFunction                  init_function;    
+};
+
+}
+
+#endif //MIROIL_SET_COMPOSITOR_H

--- a/include/miroil/miroil/set_compositor.h
+++ b/include/miroil/miroil/set_compositor.h
@@ -30,14 +30,14 @@ namespace miroil
 // Configure the server for using the Qt compositor
 class SetCompositor
 {
-    using initFunction = std::function<void(const std::shared_ptr<mir::graphics::Display>& display,
+    using InitFunction = std::function<void(const std::shared_ptr<mir::graphics::Display>& display,
                        const std::shared_ptr<Compositor> & compositor,
                        const std::shared_ptr<mir::compositor::DisplayListener>& displayListener)>;
                        
-    using constructorFunction = std::function<std::shared_ptr<Compositor>()>;    
+    using ConstructorFunction = std::function<std::shared_ptr<Compositor>()>;    
     
 public:
-    SetCompositor(constructorFunction constructor, initFunction init);
+    SetCompositor(ConstructorFunction constructor, InitFunction init);
     
     void operator()(mir::Server& server);
 
@@ -45,8 +45,8 @@ private:
     struct CompositorImpl;
     
     std::weak_ptr<CompositorImpl> compositor_impl;
-    constructorFunction           constructor_function;    
-    initFunction                  init_function;    
+    ConstructorFunction           constructor_function;    
+    InitFunction                  init_function;    
 };
 
 }

--- a/src/miroil/CMakeLists.txt
+++ b/src/miroil/CMakeLists.txt
@@ -5,6 +5,7 @@ set(miroil_include ${PROJECT_SOURCE_DIR}/include/miroil)
 add_definitions(-DMIR_LOG_COMPONENT_FALLBACK="miroil" -DMIROIL_ENABLE_DEPRECATIONS=0)
 
 add_library(miroil SHARED
+    compositor.cpp ${miroil_include}/miroil/compositor.h    
     edid.cpp ${miroil_include}/miroil/edid.h
     mirbuffer.cpp ${miroil_include}/miroil/mirbuffer.h
     persist_display_config.cpp ${miroil_include}/miroil/persist_display_config.h
@@ -16,6 +17,7 @@ add_library(miroil SHARED
     mir_server_hooks.cpp ${miroil_include}/miroil/mir_server_hooks.h
     prompt_session_listener.cpp ${miroil_include}/miroil/prompt_session_listener.h
     prompt_session_manager.cpp ${miroil_include}/miroil/prompt_session_manager.h    
+    set_compositor.cpp ${miroil_include}/miroil/set_compositor.h
     ${miroil_include}/miroil/display_configuration_storage.h
     ${miroil_include}/miroil/display_id.h
 )

--- a/src/miroil/compositor.cpp
+++ b/src/miroil/compositor.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016-2021 Canonical, Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <miroil/compositor.h>
+
+miroil::Compositor::~Compositor() = default;
+

--- a/src/miroil/set_compositor.cpp
+++ b/src/miroil/set_compositor.cpp
@@ -58,7 +58,7 @@ void SetCompositor::CompositorImpl::stop()
     return custom_compositor->stop();
 }
 
-SetCompositor::SetCompositor(constructorFunction constr, initFunction init)
+SetCompositor::SetCompositor(ConstructorFunction constr, InitFunction init)
     : constructor_function(constr), init_function(init)
 {
 }

--- a/src/miroil/set_compositor.cpp
+++ b/src/miroil/set_compositor.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "miroil/set_compositor.h"
+#include "miroil/compositor.h"
+#include <stdexcept>
+
+// mir
+#include <mir/server.h>
+#include <mir/shell/shell.h>
+#include <mir/compositor/compositor.h>
+
+namespace miroil {
+
+struct SetCompositor::CompositorImpl : public mir::compositor::Compositor
+{
+    CompositorImpl(const std::shared_ptr<miroil::Compositor> & compositor);
+    
+    auto get_wrapped() -> std::shared_ptr<miroil::Compositor>;    
+    void start();
+    void stop();
+    
+    std::shared_ptr<miroil::Compositor> custom_compositor;
+};
+
+SetCompositor::CompositorImpl::CompositorImpl(const std::shared_ptr<miroil::Compositor> & compositor) 
+: custom_compositor(compositor)
+{
+}
+    
+auto SetCompositor::CompositorImpl::get_wrapped() 
+-> std::shared_ptr<miroil::Compositor>
+{ 
+    return custom_compositor;     
+}
+
+
+void SetCompositor::CompositorImpl::start()
+{
+    return custom_compositor->start();
+}
+
+void SetCompositor::CompositorImpl::stop()
+{
+    return custom_compositor->stop();
+}
+
+SetCompositor::SetCompositor(constructorFunction constr, initFunction init)
+    : constructor_function(constr), init_function(init)
+{
+}
+
+void SetCompositor::operator()(mir::Server& server)
+{
+    server.override_the_compositor([this]
+    {
+        auto result = std::make_shared<CompositorImpl>(constructor_function());
+        compositor_impl = result;
+        return result;
+    });
+
+    server.add_init_callback([&, this]
+        {
+            if (auto const comp = compositor_impl.lock())
+            {
+                init_function(server.the_display(), comp->get_wrapped(), server.the_shell());
+            }
+            else
+            {
+                throw std::logic_error("No m_compositor available. Server not running?");
+            }
+        });
+}
+
+}

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -1,6 +1,9 @@
 MIROIL_1.0 {
 global:
   extern "C++" {
+    miroil::Compositor::?Compositor*;
+    miroil::Compositor::Compositor*;
+    miroil::Compositor::operator*;
     miroil::DisplayConfigurationPolicy::?DisplayConfigurationPolicy*;
     miroil::DisplayConfigurationPolicy::DisplayConfigurationPolicy*;
     miroil::DisplayConfigurationPolicy::operator*;
@@ -56,11 +59,15 @@ global:
     miroil::PromptSessionManager::resume_prompt_session*;
     miroil::PromptSessionManager::stop_prompt_session*;
     miroil::PromptSessionManager::suspend_prompt_session*;
+    miroil::SetCompositor::SetCompositor*;
+    miroil::SetCompositor::operator*;
     miroil::dispatch_input_event*;
+    non-virtual?thunk?to?miroil::Compositor::?Compositor*;
     non-virtual?thunk?to?miroil::DisplayConfigurationPolicy::?DisplayConfigurationPolicy*;
     non-virtual?thunk?to?miroil::DisplayConfigurationStorage::?DisplayConfigurationStorage*;
     non-virtual?thunk?to?miroil::InputDeviceObserver::?InputDeviceObserver*;
     non-virtual?thunk?to?miroil::PromptSessionListener::?PromptSessionListener*;
+    typeinfo?for?miroil::Compositor;
     typeinfo?for?miroil::DisplayConfigurationOptions;
     typeinfo?for?miroil::DisplayConfigurationOptions::DisplayMode;
     typeinfo?for?miroil::DisplayConfigurationPolicy;
@@ -78,6 +85,8 @@ global:
     typeinfo?for?miroil::PersistDisplayConfig;
     typeinfo?for?miroil::PromptSessionListener;
     typeinfo?for?miroil::PromptSessionManager;
+    typeinfo?for?miroil::SetCompositor;
+    vtable?for?miroil::Compositor;
     vtable?for?miroil::DisplayConfigurationOptions;
     vtable?for?miroil::DisplayConfigurationOptions::DisplayMode;
     vtable?for?miroil::DisplayConfigurationPolicy;
@@ -95,6 +104,7 @@ global:
     vtable?for?miroil::PersistDisplayConfig;
     vtable?for?miroil::PromptSessionListener;
     vtable?for?miroil::PromptSessionManager;
+    vtable?for?miroil::SetCompositor;
   };
 
 local: *;


### PR DESCRIPTION
Moving SetQtComposer to miroil::SetCompositor
Adding a wrapper for QtCompositor (miroil::SetCompositor::CompositorImpl)
And an interface to be wrapped miroil::Compositor
