### PR TITLE
Miroil move open gl context to miroil 2

### DIFF
--- a/include/miroil/miroil/open_gl_context.h
+++ b/include/miroil/miroil/open_gl_context.h
@@ -29,7 +29,7 @@ namespace miroil
 class OpenGLContext
 {
 public:
-    OpenGLContext(mir::graphics::GLConfig* glConfig);
+    OpenGLContext(mir::graphics::GLConfig* gl_config);
 
     void operator()(mir::Server& server);
     auto the_open_gl_config() const -> std::shared_ptr<mir::graphics::GLConfig>;

--- a/include/miroil/miroil/open_gl_context.h
+++ b/include/miroil/miroil/open_gl_context.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef MIROIL_OPEN_GL_CONTEXT_H
+#define MIROIL_OPEN_GL_CONTEXT_H
+#include <mir/graphics/gl_config.h>
+#include <memory>
+#include <functional>
+
+namespace mir { class Server; }
+
+namespace miroil
+{
+class OpenGLContext
+{
+public:
+    OpenGLContext(mir::graphics::GLConfig* glConfig);
+
+    void operator()(mir::Server& server);
+    auto the_open_gl_config() const -> std::shared_ptr<mir::graphics::GLConfig>;
+
+private:
+    struct Self;
+    std::shared_ptr<Self> self;
+};
+}
+
+#endif //MIROIL_OPEN_GL_CONTEXT_H

--- a/src/miroil/CMakeLists.txt
+++ b/src/miroil/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(miroil SHARED
     input_device.cpp ${miroil_include}/miroil/input_device.h
     input_device_observer.cpp ${miroil_include}/miroil/input_device_observer.h
     mir_server_hooks.cpp ${miroil_include}/miroil/mir_server_hooks.h
+    open_gl_context.cpp ${miroil_include}/miroil/open_gl_context.h    
     prompt_session_listener.cpp ${miroil_include}/miroil/prompt_session_listener.h
     prompt_session_manager.cpp ${miroil_include}/miroil/prompt_session_manager.h    
     set_compositor.cpp ${miroil_include}/miroil/set_compositor.h

--- a/src/miroil/open_gl_context.cpp
+++ b/src/miroil/open_gl_context.cpp
@@ -21,10 +21,8 @@
 
 // mir
 #include <mir/server.h>
-
-namespace miroil {
-    
-struct OpenGLContext::Self
+   
+struct miroil::OpenGLContext::Self
 {
     Self(mir::graphics::GLConfig * glConfig)
     : m_glConfig(glConfig) 
@@ -34,21 +32,21 @@ struct OpenGLContext::Self
     std::shared_ptr<mir::graphics::GLConfig> m_glConfig;
 };
 
-OpenGLContext::OpenGLContext(mir::graphics::GLConfig * glConfig)
+miroil::OpenGLContext::OpenGLContext(mir::graphics::GLConfig * glConfig)
 :    self{std::make_shared<Self>(glConfig)}
 {    
 }
 
-void OpenGLContext::operator()(mir::Server& server)
+void miroil::OpenGLContext::operator()(mir::Server& server)
 {
     server.override_the_gl_config([this]
         { return self->m_glConfig; }
     );
 }
 
-auto OpenGLContext::the_open_gl_config() const
+auto miroil::OpenGLContext::the_open_gl_config() const
 -> std::shared_ptr<mir::graphics::GLConfig>
 {
     return self->m_glConfig;
 }
-}
+

--- a/src/miroil/open_gl_context.cpp
+++ b/src/miroil/open_gl_context.cpp
@@ -24,29 +24,29 @@
    
 struct miroil::OpenGLContext::Self
 {
-    Self(mir::graphics::GLConfig * glConfig)
-    : m_glConfig(glConfig) 
+    Self(mir::graphics::GLConfig* gl_config)
+    : gl_config(gl_config)
     {        
     }
     
-    std::shared_ptr<mir::graphics::GLConfig> m_glConfig;
+    std::shared_ptr<mir::graphics::GLConfig> const gl_config;
 };
 
-miroil::OpenGLContext::OpenGLContext(mir::graphics::GLConfig * glConfig)
-:    self{std::make_shared<Self>(glConfig)}
+miroil::OpenGLContext::OpenGLContext(mir::graphics::GLConfig* gl_config)
+:    self{std::make_shared<Self>(gl_config)}
 {    
 }
 
 void miroil::OpenGLContext::operator()(mir::Server& server)
 {
     server.override_the_gl_config([this]
-        { return self->m_glConfig; }
+        { return self->gl_config; }
     );
 }
 
 auto miroil::OpenGLContext::the_open_gl_config() const
 -> std::shared_ptr<mir::graphics::GLConfig>
 {
-    return self->m_glConfig;
+    return self->gl_config;
 }
 

--- a/src/miroil/open_gl_context.cpp
+++ b/src/miroil/open_gl_context.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2016 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "miroil/open_gl_context.h"
+#include <stdexcept>
+
+// mir
+#include <mir/server.h>
+
+namespace miroil {
+    
+struct OpenGLContext::Self
+{
+    Self(mir::graphics::GLConfig * glConfig)
+    : m_glConfig(glConfig) 
+    {        
+    }
+    
+    std::shared_ptr<mir::graphics::GLConfig> m_glConfig;
+};
+
+OpenGLContext::OpenGLContext(mir::graphics::GLConfig * glConfig)
+:    self{std::make_shared<Self>(glConfig)}
+{    
+}
+
+void OpenGLContext::operator()(mir::Server& server)
+{
+    server.override_the_gl_config([this]
+        { return self->m_glConfig; }
+    );
+}
+
+auto OpenGLContext::the_open_gl_config() const
+-> std::shared_ptr<mir::graphics::GLConfig>
+{
+    return self->m_glConfig;
+}
+}

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -46,6 +46,9 @@ global:
     miroil::MirServerHooks::the_mir_display*;
     miroil::MirServerHooks::the_prompt_session_listener*;
     miroil::MirServerHooks::the_prompt_session_manager*;
+    miroil::OpenGLContext::OpenGLContext*;
+    miroil::OpenGLContext::operator*;
+    miroil::OpenGLContext::the_open_gl_config*;
     miroil::PersistDisplayConfig::?PersistDisplayConfig*;
     miroil::PersistDisplayConfig::PersistDisplayConfig*;
     miroil::PersistDisplayConfig::operator*;
@@ -82,6 +85,7 @@ global:
     typeinfo?for?miroil::InputDevice;
     typeinfo?for?miroil::InputDeviceObserver;
     typeinfo?for?miroil::MirServerHooks;
+    typeinfo?for?miroil::OpenGLContext;
     typeinfo?for?miroil::PersistDisplayConfig;
     typeinfo?for?miroil::PromptSessionListener;
     typeinfo?for?miroil::PromptSessionManager;
@@ -101,6 +105,7 @@ global:
     vtable?for?miroil::InputDevice;
     vtable?for?miroil::InputDeviceObserver;
     vtable?for?miroil::MirServerHooks;
+    vtable?for?miroil::OpenGLContext;
     vtable?for?miroil::PersistDisplayConfig;
     vtable?for?miroil::PromptSessionListener;
     vtable?for?miroil::PromptSessionManager;


### PR DESCRIPTION
Moving OpenGlContextFactory to mir.
And since it does not create the OpenGlContext any more... I have renamed it to OpenGlContext